### PR TITLE
npm install -g conventional-changelog-cli

### DIFF
--- a/2016/2016-01-06-commit-message.md
+++ b/2016/2016-01-06-commit-message.md
@@ -233,7 +233,7 @@ INVALID COMMIT MSG: does not match "<type>(<scope>): <subject>" ! was: edit mark
 [conventional-changelog](https://github.com/ajoslin/conventional-changelog) 就是生成 Change log 的工具，运行下面的命令即可。
 
 ```bash
-$ npm install -g conventional-changelog
+$ npm install -g conventional-changelog-cli
 $ cd my-project
 $ conventional-changelog -p angular -i CHANGELOG.md -w
 ```


### PR DESCRIPTION
生成changelog的npm模块需要安装CLI版本conventional-changelog-cli。

参考官方README的[quick start](https://github.com/conventional-changelog/conventional-changelog-cli)